### PR TITLE
chore: sync hardened commit-msg hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,2 +1,7 @@
 #!/usr/bin/env bash
-npx -y conventional-commit-msg "$1"
+# `@latest` + explicit `--package` dodge two npm footguns: an inherited
+# npm_config_package (agent wrappers like axexec/axrun set it, hijacking
+# `npx -y` into exit 127), and local-root shadowing — without the version,
+# `npm exec` resolves the conventional-commit-msg repo's own package and the
+# bin is "not found", breaking the hook in that repo after prepare wires it up.
+npm exec --yes --package=conventional-commit-msg@latest -- conventional-commit-msg "$1"


### PR DESCRIPTION
Syncs the managed `.githooks/commit-msg` hook to j4k-align's hardened form (pinned `npm exec --yes --package=conventional-commit-msg@latest`), which is immune to `npm_config_package` env poisoning that breaks the old `npx -y` invocation.
